### PR TITLE
Output dat boi when require()'d

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-require("./datboi");
+require("./datboi")();


### PR DESCRIPTION
To use datboi I had to run `require('datboi/datboi')()`.  Which is no biggie!  But I think this change is more in line with the usage section of the readme.  Thanks for your work 👍 